### PR TITLE
Add CSRF-protected form support and middleware

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -859,39 +859,36 @@ async def delete_user(user_id: PathParam[int]) -> JSON:
 ### Form Handling
 
 ```python
+from dataclasses import dataclass
+from serving.forms import Form, CSRFProtection
 from serving.router import Router
-from serving.types import HTML, Jinja2
-from starlette.requests import Request
-from bevy import dependency
+from serving.types import Jinja2
 
 app = Router()
 
-@app.route("/contact", methods={"GET"})
-async def contact_form() -> HTML:
-    return """
-    <form method="post" action="/contact">
-        <input name="name" placeholder="Your Name" required>
-        <input name="email" type="email" placeholder="Your Email" required>
-        <textarea name="message" placeholder="Your Message" required></textarea>
-        <button type="submit">Send</button>
-    </form>
-    """
+@dataclass
+class Login(Form, template="login.html"):
+    username: str
+    password: str
+    confirm_password: str
 
-@app.route("/contact", methods={"POST"})
-async def handle_contact(request: Request = dependency()) -> HTML:
-    form = await request.form()
-    name = form["name"]
-    email = form["email"]
-    message = form["message"]
-    
-    # Process the form data (e.g., send email, save to database)
-    # ...
-    
-    return f"""
-    <h1>Thank you, {name}!</h1>
-    <p>We'll respond to {email} soon.</p>
-    <p>Your message: {message}</p>
-    """
+@app.route("/login")
+async def show_login() -> Jinja2:
+    return "page.html", {"login_form": Login(username="", password="", confirm_password="")}
+
+# login.html
+# <form method="post">
+#     {{ csrf() }}
+#     <input name="username" value="{{ form.username }}">
+#     <input name="password" type="password" value="{{ form.password }}">
+#     <input name="confirm_password" type="password" value="{{ form.confirm_password }}">
+# </form>
+
+# If csrf() is omitted, rendering raises MissingCSRFTokenError
+
+# Disable CSRF explicitly
+class Search(Form, template="search.html", csrf=CSRFProtection.Disabled):
+    query: str
 ```
 
 ### File Upload

--- a/USAGE.md
+++ b/USAGE.md
@@ -106,8 +106,33 @@ For more complex scenarios or to group related endpoints, you can create classes
   class DemoRoutesExtension(Extension):
       async def on_app_request_begin(self, router: Router = dependency()):
           router.add_route("/", HomeRoute) # Registers all handlers in HomeRoute for "/"
-          router.add_route("/submit", SubmitRoute)
+      router.add_route("/submit", SubmitRoute)
   ```
+
+A form can also be defined directly using the base `Form` type:
+
+```python
+from dataclasses import dataclass
+from serving.forms import Form, CSRFProtection
+
+@dataclass
+class Login(Form, template="login.html"):
+    username: str
+    password: str
+    confirm_password: str
+
+class Search(Form, template="search.html", csrf=CSRFProtection.Disabled):
+    query: str
+```
+`login.html` must call `{{ csrf() }}` to inject the synchronizer token:
+
+```html
+<form method="post">
+  {{ csrf() }}
+  <input name="username" value="{{ form.username }}">
+  ...
+</form>
+```
     When `router.add_route()` receives a `Route` class, it registers all implicitly discovered handlers (method-based and form-based) from that class.
 
 **3. Path Parameters:**

--- a/src/serving/__init__.py
+++ b/src/serving/__init__.py
@@ -1,5 +1,6 @@
 from serving.serv import Serv
 from serving.response import set_header, set_status_code, set_cookie, delete_cookie, redirect
+from serving.forms import Form, CSRFProtection
 
-__all__ = ["Serv"]
+__all__ = ["Serv", "Form", "CSRFProtection"]
 __version__ = "0.1.0"

--- a/src/serving/csrf_middleware.py
+++ b/src/serving/csrf_middleware.py
@@ -1,0 +1,26 @@
+from bevy import Inject, auto_inject, injectable
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse
+from starlette.status import HTTP_400_BAD_REQUEST
+
+from serving.auth import CredentialProvider
+
+
+class CSRFMiddleware(BaseHTTPMiddleware):
+    @auto_inject
+    @injectable
+    async def dispatch(
+        self,
+        request: Request,
+        call_next,
+        credential_provider: Inject[CredentialProvider],
+    ):
+        if request.method in {"POST", "PUT", "PATCH", "DELETE"}:
+            form = await request.form()
+            token = form.get("csrf_token")
+            if not token or not credential_provider.validate_csrf_token(token):
+                return PlainTextResponse(
+                    "Invalid CSRF token", status_code=HTTP_400_BAD_REQUEST
+                )
+        return await call_next(request)

--- a/src/serving/forms.py
+++ b/src/serving/forms.py
@@ -1,0 +1,77 @@
+from enum import Enum
+from typing import Any
+from bevy import Inject, auto_inject, injectable
+from starlette.requests import Request
+from starlette.templating import Jinja2Templates
+from markupsafe import Markup
+
+from serving.auth import CredentialProvider
+
+
+class CSRFProtection(Enum):
+    Enabled = "enabled"
+    Disabled = "disabled"
+
+
+class MissingCSRFTokenError(RuntimeError):
+    """Raised when a form template fails to render a CSRF token."""
+
+
+class Form:
+    __form_options__: dict[str, Any]
+
+    def __init_subclass__(
+        cls, *, template: str, csrf: CSRFProtection = CSRFProtection.Enabled, **kwargs
+    ):
+        super().__init_subclass__(**kwargs)
+        cls.__form_options__ = {"template": template, "csrf": csrf}
+
+    @auto_inject
+    @injectable
+    def render(
+        self,
+        templates: Inject[Jinja2Templates],
+        credential_provider: Inject[CredentialProvider],
+    ) -> str:
+        options = self.__form_options__
+        context: dict[str, Any] = {"form": self}
+
+        if options["csrf"] is CSRFProtection.Enabled:
+            token = credential_provider.generate_csrf_token()
+            called = False
+
+            def csrf() -> Markup:
+                nonlocal called
+                called = True
+                return Markup(
+                    f'<input type="hidden" name="csrf_token" value="{token}">'  # noqa: B907
+                )
+
+            context["csrf"] = csrf
+
+            template = templates.get_template(options["template"])
+            result = template.render(context)
+            if not called:
+                raise MissingCSRFTokenError(
+                    "CSRF token was not injected; call csrf() in the form template"
+                )
+            return result
+
+        return templates.get_template(options["template"]).render(context)
+
+    @classmethod
+    @auto_inject
+    @injectable
+    async def from_request[T: "Form"](
+        cls: type[T],
+        request: Inject[Request],
+        credential_provider: Inject[CredentialProvider],
+    ) -> T:
+        form = await request.form()
+        options = cls.__form_options__
+        if options["csrf"] is CSRFProtection.Enabled:
+            token = form.get("csrf_token")
+            if not token or not credential_provider.validate_csrf_token(token):
+                raise ValueError("Invalid CSRF token")
+        data = {k: form.get(k) for k in cls.__annotations__.keys() if k in form}
+        return cls(**data)

--- a/src/tests/serving/test_forms.py
+++ b/src/tests/serving/test_forms.py
@@ -1,0 +1,178 @@
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlencode
+
+import pytest
+from bevy import Inject, auto_inject, injectable
+from bevy.registries import Registry
+from starlette.requests import Request
+from starlette.templating import Jinja2Templates
+
+from serving.auth import CredentialProvider
+from serving.forms import CSRFProtection, Form, MissingCSRFTokenError
+from serving.injectors import handle_form_types
+
+
+class DummyCredentialProvider:
+    def has_credentials(self, permissions: set[str]) -> bool:
+        return True
+
+    def generate_csrf_token(self) -> str:
+        return "token"
+
+    def validate_csrf_token(self, token: str) -> bool:
+        return token == "token"
+
+
+def setup_container(tmp_path: Path):
+    registry = Registry()
+    container = registry.create_container()
+    templates = Jinja2Templates(directory=tmp_path)
+    container.add(templates)
+    container.add(CredentialProvider, DummyCredentialProvider())
+    handle_form_types.register_hook(registry)
+    return container
+
+
+def test_form_render_includes_csrf_token(tmp_path):
+    (tmp_path / "login.html").write_text("{{ form.username }} {{ csrf() }}")
+    container = setup_container(tmp_path)
+
+    @dataclass
+    class Login(Form, template="login.html"):
+        username: str
+
+    with container.branch():
+        result = Login(username="alice").render()
+
+    assert "alice" in result
+    assert '<input type="hidden" name="csrf_token" value="token">' in result
+
+
+def test_form_render_without_csrf_when_disabled(tmp_path):
+    (tmp_path / "login.html").write_text("no token here")
+    container = setup_container(tmp_path)
+
+    @dataclass
+    class NoCSRF(Form, template="login.html", csrf=CSRFProtection.Disabled):
+        pass
+
+    with container.branch():
+        result = NoCSRF().render()
+
+    assert "csrf_token" not in result
+
+
+@pytest.mark.asyncio
+async def test_from_request_validates_csrf(tmp_path):
+    (tmp_path / "login.html").write_text("")
+    container = setup_container(tmp_path)
+
+    @dataclass
+    class Login(Form, template="login.html"):
+        username: str
+
+    body = urlencode({"username": "alice", "csrf_token": "token"}).encode()
+    headers = [
+        (b"content-type", b"application/x-www-form-urlencoded"),
+        (b"content-length", str(len(body)).encode()),
+    ]
+    scope = {"type": "http", "method": "POST", "path": "/", "headers": headers}
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    request = Request(scope, receive=receive)
+
+    with container.branch():
+        form = await Login.from_request(request)
+
+    assert form.username == "alice"
+
+
+@pytest.mark.asyncio
+async def test_from_request_invalid_csrf(tmp_path):
+    (tmp_path / "login.html").write_text("")
+    container = setup_container(tmp_path)
+
+    @dataclass
+    class Login(Form, template="login.html"):
+        username: str
+
+    body = urlencode({"username": "alice", "csrf_token": "bad"}).encode()
+    headers = [
+        (b"content-type", b"application/x-www-form-urlencoded"),
+        (b"content-length", str(len(body)).encode()),
+    ]
+    scope = {"type": "http", "method": "POST", "path": "/", "headers": headers}
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    request = Request(scope, receive=receive)
+
+    with container.branch():
+        with pytest.raises(ValueError):
+            await Login.from_request(request)
+
+
+def test_form_field_name_conflicts(tmp_path):
+    (tmp_path / "conflict.html").write_text("{{ form.template }} {{ form.csrf }} {{ csrf() }}")
+    container = setup_container(tmp_path)
+
+    @dataclass
+    class Conflict(Form, template="conflict.html"):
+        template: str
+        csrf: str
+
+    with container.branch():
+        result = Conflict(template="foo", csrf="bar").render()
+
+    assert "foo" in result
+    assert "bar" in result
+def test_form_render_raises_when_csrf_missing(tmp_path):
+    (tmp_path / "login.html").write_text("{{ form.username }}")
+    container = setup_container(tmp_path)
+
+    @dataclass
+    class Login(Form, template="login.html"):
+        username: str
+
+    with container.branch():
+        with pytest.raises(MissingCSRFTokenError):
+            Login(username="alice").render()
+
+
+def test_form_injection_uses_cached_instance(tmp_path):
+    (tmp_path / "simple.html").write_text("")
+    container = setup_container(tmp_path)
+
+    @dataclass
+    class Simple(Form, template="simple.html", csrf=CSRFProtection.Disabled):
+        name: str
+
+    body = urlencode({"name": "alice"}).encode()
+    headers = [
+        (b"content-type", b"application/x-www-form-urlencoded"),
+        (b"content-length", str(len(body)).encode()),
+    ]
+    scope = {"type": "http", "method": "POST", "path": "/", "headers": headers}
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    request = Request(scope, receive=receive)
+
+    with container.branch() as c:
+        c.add(Request, request)
+
+        @auto_inject
+        @injectable
+        def use_form(form1: Inject[Simple], form2: Inject[Simple]):
+            return form1, form2
+
+        form1, form2 = c.call(use_form)
+
+    assert form1.name == "alice"
+    assert form1 is form2
+


### PR DESCRIPTION
## Summary
- inject a `csrf()` helper into forms that renders a hidden token field
- raise `MissingCSRFTokenError` when a CSRF-protected form template omits the helper
- document required `csrf()` usage and update tests
- modernize generics to Python 3.12 syntax
- add form injector that builds `Form` subclasses from the current request and caches the instance

## Testing
- `pip install 'bevy==3.1.0b6' starlette jinja2 pyyaml pytest-asyncio python-multipart`
- `pytest src/tests/serving/test_forms.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68be15d328bc832198e04a37743665db